### PR TITLE
"Command not found" Fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,9 @@ cd ~/tools/
 #install aquatone
 echo "Installing Aquatone"
 go get github.com/michenriksen/aquatone
+cd ~/go/bin/
+sudo mv aquatone /usr/local/bin
+cd ~/tools/
 echo "done"
 
 #install chromium
@@ -162,14 +165,23 @@ echo "done"
 
 echo "installing httprobe"
 go get -u github.com/tomnomnom/httprobe 
+cd ~/go/bin/
+sudo mv httprobe /usr/local/bin
+cd ~/tools/
 echo "done"
 
 echo "installing unfurl"
-go get -u github.com/tomnomnom/unfurl 
+go get -u github.com/tomnomnom/unfurl
+cd ~/go/bin/
+sudo mv unfurl /usr/local/bin
+cd ~/tools/
 echo "done"
 
 echo "installing waybackurls"
 go get github.com/tomnomnom/waybackurls
+cd ~/go/bin/
+sudo mv waybackurls /usr/local/bin
+cd ~/tools/
 echo "done"
 
 echo "downloading Seclists"


### PR DESCRIPTION
So while using aquatone, unfurl, waybackurls or httprobe as per their documentation by creators. There will be error of Command not found in Linux. So, a simple fix is implemented to make things as per documentation.