### PR TITLE
Go tools installation fix & .bash_profile installation fix 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ sudo apt-get install -y xargs
 echo "installing bash_profile aliases from recon_profile"
 git clone https://github.com/nahamsec/recon_profile.git
 cd recon_profile
-cat bash_profile >> ~/.bash_profile
+cat .bash_profile >> ~/.bash_profile
 source ~/.bash_profile
 cd ~/tools/
 echo "done"
@@ -74,7 +74,7 @@ cd ~/tools/
 
 #install aquatone
 echo "Installing Aquatone"
-go get github.com/michenriksen/aquatone
+go install github.com/michenriksen/aquatone@latest
 echo "done"
 
 #install chromium
@@ -161,15 +161,15 @@ cd ~/tools/
 echo "done"
 
 echo "installing httprobe"
-go get -u github.com/tomnomnom/httprobe 
+go install github.com/tomnomnom/httprobe@latest
 echo "done"
 
 echo "installing unfurl"
-go get -u github.com/tomnomnom/unfurl 
+go install github.com/tomnomnom/unfurl@latest
 echo "done"
 
 echo "installing waybackurls"
-go get github.com/tomnomnom/waybackurls
+go install github.com/tomnomnom/waybackurls@latest
 echo "done"
 
 echo "installing crtndstry"


### PR DESCRIPTION
Period/dot sign was missing in the code that's why .recon_profile was not getting ready. Also GO tools were not working in go1.17.5 so had to make some edits in go tools setup module