### PR TITLE
recon_profile, golang installation, golang update

### DIFF
--- a/fix-note.md
+++ b/fix-note.md
@@ -1,0 +1,12 @@
+While i was installing bbht it was not creating ".bash_profile" aliases, i had to fix the code everytime is create a vps or vm. 
+And now im facing problem while installing bbht GOLANG tools as GOLANG version 1.17.5 does'nt suppport 'go get', instead it used 'go install github.com/user/toolName@latest'
+
+So i made some small changes to use it in easy was! 
+
+# Fix 1 : Bash profile
+# Fix 2 : Golang tools installation
+# Fix 3 : Golang version updated
+
+
+
+

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ sudo apt-get install -y xargs
 echo "installing bash_profile aliases from recon_profile"
 git clone https://github.com/nahamsec/recon_profile.git
 cd recon_profile
-cat bash_profile >> ~/.bash_profile
+cat .bash_profile >> ~/.bash_profile
 source ~/.bash_profile
 cd ~/tools/
 echo "done"
@@ -38,7 +38,7 @@ select choice in "${choices[@]}"; do
                 yes)
 
 					echo "Installing Golang"
-					wget https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz
+					wget https://go.dev/dl/go1.19.linux-amd64.tar.gz
 					sudo tar -xvf go1.13.4.linux-amd64.tar.gz
 					sudo mv go /usr/local
 					export GOROOT=/usr/local/go
@@ -74,7 +74,7 @@ cd ~/tools/
 
 #install aquatone
 echo "Installing Aquatone"
-go get github.com/michenriksen/aquatone
+go install github.com/michenriksen/aquatone@latest
 echo "done"
 
 #install chromium
@@ -161,15 +161,15 @@ cd ~/tools/
 echo "done"
 
 echo "installing httprobe"
-go get -u github.com/tomnomnom/httprobe 
+go install github.com/tomnomnom/httprobe@latest
 echo "done"
 
 echo "installing unfurl"
-go get -u github.com/tomnomnom/unfurl 
+go install github.com/tomnomnom/unfurl@latest
 echo "done"
 
 echo "installing waybackurls"
-go get github.com/tomnomnom/waybackurls
+go install github.com/tomnomnom/waybackurls@latest
 echo "done"
 
 echo "installing crtndstry"


### PR DESCRIPTION
While i was installing bbht it was not creating ".bash_profile" aliases, i had to fix the code everytime is create a vps or vm. 
And now im facing problem while installing bbht GOLANG tools as GOLANG version 1.17.5 does'nt suppport 'go get', instead it used 'go install github.com/user/toolName@latest'

So i made some small changes to use it in easy was! 

# Fix 1 : Bash profile
# Fix 2 : Golang tools installation
# Fix 3 : Golang version updated
